### PR TITLE
v18.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,15 @@
+turnkey-xoops-18.0 (1) turnkey; urgency=low
+
+  * Upgraded to latest upstream version of XOOPS - 2.5.11.
+
+  * Updated all relevant Debian packages to Bookworm/12 versions; including
+    PHP 8.2.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Anton Pyrogovskyi <anton@turnkeylinux.org>  Tue, 13 Feb 2024 15:24:17 +0100
+
 turnkey-xoops-17.1 (1) turnkey; urgency=low
 
   * Updated all Debian packages to latest.

--- a/conf.d/downloads
+++ b/conf.d/downloads
@@ -6,7 +6,7 @@ dl() {
 }
 
 
-VERSION="v2.5.10"
+VERSION="v2.5.11"
 URL="https://github.com/XOOPS/XoopsCore25/archive/$VERSION.tar.gz"
 
 dl $URL /usr/local/src

--- a/conf.d/main
+++ b/conf.d/main
@@ -20,17 +20,12 @@ tar -zxf $SRC/$VERSION.tar.gz -C $SRC
 cp -a $SRC/XoopsCore*/htdocs $WEBROOT
 cp $SRC/XoopsCore*/extras/mainfile.php $WEBROOT
 rm -rf $SRC/XoopsCore*
-chown -R root:root $WEBROOT
-chown -R www-data:www-data $WEBROOT/uploads
-chown www-data:www-data $WEBROOT/mainfile.php
-chown www-data:www-data $WEBROOT/include/license.php
 
 mkdir -p $XOOPS
 mv $WEBROOT/xoops_lib $XOOPS/lib
 mv $WEBROOT/xoops_data $XOOPS/data
-chown -R www-data:www-data $XOOPS/data/caches
-chown -R www-data:www-data $XOOPS/data/data
-chown -R www-data:www-data $XOOPS/lib/modules/protector/configs/
+
+chown -R www-data:www-data $WEBROOT $XOOPS
 
 # configure apache
 a2dissite 000-default
@@ -105,6 +100,14 @@ $MYSQL_BATCH --database=$DB_NAME --execute "DELETE FROM ${DB_PREFIX}_banner WHER
 sed -i "s|XOOPS_URL.*|XOOPS_URL', '');|g" $WEBROOT/mainfile.php
 
 # secure sensitive files
+chown -R root:root $WEBROOT $XOOPS
+chown -R www-data:www-data $WEBROOT/uploads
+chown www-data:www-data $WEBROOT/mainfile.php
+chown www-data:www-data $WEBROOT/include/license.php
+chown -R www-data:www-data $XOOPS/data/caches
+chown -R www-data:www-data $XOOPS/data/data
+chown -R www-data:www-data $XOOPS/lib/modules/protector/configs/
+
 chmod 440 $WEBROOT/mainfile.php
 chmod 440 $XOOPS/data/data/secure.php
 

--- a/conf.d/main
+++ b/conf.d/main
@@ -13,7 +13,7 @@ SRC=/usr/local/src
 WEBROOT=/var/www/xoops
 XOOPS=/var/local/lib/xoops
 
-VERSION=v2.5.10
+VERSION=v2.5.11
 
 # unpack and configure
 tar -zxf $SRC/$VERSION.tar.gz -C $SRC


### PR DESCRIPTION
- bump xoops version to 2.5.11
- rearrange chown order to allow xoops install
- update changelog
